### PR TITLE
add FORMAT to header as per VCFv4.2 spec

### DIFF
--- a/msa2vcf/msa2vcf.py
+++ b/msa2vcf/msa2vcf.py
@@ -174,7 +174,7 @@ def make_vcf(snps, qname, rname, keep_n):
     vcflines.append("##contig=<ID=" + rname + ">")
     vcflines.append("##INFO=<ID=DP,Number=1,Type=Integer,Description=\"Total Depth\">")
     vcflines.append("##INFO=<ID=AF,Number=A,Type=Float,Description=\"Allele Frequency\">")
-    vcflines.append("#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\t"+qname)
+    vcflines.append("#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t"+qname)
 
     # variants
     for line in snps:


### PR DESCRIPTION
Since msa2vcf includes the sample name in the header, I think "FORMAT" needs to occur before it. This prevented files written by msa2vcf from being read by some VCF parsers.

Spec: https://samtools.github.io/hts-specs/VCFv4.2.pdf